### PR TITLE
Tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - tokens linked list became tokens **double** linked list
+- new tokend types: `T_PIPE` `T_REDIRECT` `T_HERE_DOC` `T_FILE`
 
 ## - 2021-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## - 2021-07-22
+
+### Changed
+- tokens linked list became tokens **double** linked list
+
 ## - 2021-07-18
 ### Added
 - Added `get_absolute_path()` function, that retrieves the correct path for a specified binary based on the PATH environment variable, or returns NULL if it can't find it.

--- a/includes/tokenizer.h
+++ b/includes/tokenizer.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 14:59:12 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 00:16:55 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 17:34:00 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ typedef struct s_token
 	int				type;
 	char			*value;
 	struct s_token	*next;
+	struct s_token	*previous;
 }	t_token;
 
 typedef struct s_var

--- a/includes/tokenizer.h
+++ b/includes/tokenizer.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 14:59:12 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/21 23:29:38 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 00:16:55 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@
 # define T_PIPE			44
 # define T_REDIRECT		45
 # define T_HERE_DOC		46
+# define T_FILE			47
 
 # define SINGLE_QUOTE	'\''
 # define DOUBLE_QUOTE	'\"'
@@ -72,5 +73,9 @@ void	free_var_struct(t_var *var);
 void	define_type(char *value, int *type);
 bool	is_redirect(char *value);
 bool	is_builtin(char *value);
+/*
+** debugging_temp.c
+*/
+void	print_token_lst(t_token *token_lst);
 
 #endif

--- a/includes/tokenizer.h
+++ b/includes/tokenizer.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 14:59:12 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/18 22:02:31 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/21 23:29:38 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,10 @@
 # include <stdbool.h>
 
 # define T_BUILTIN		42
-# define T_OPERATOR		43
-# define T_LITERAL		44
+# define T_LITERAL		43
+# define T_PIPE			44
+# define T_REDIRECT		45
+# define T_HERE_DOC		46
 
 # define SINGLE_QUOTE	'\''
 # define DOUBLE_QUOTE	'\"'
@@ -68,5 +70,7 @@ void	free_var_struct(t_var *var);
 ** define_type.c
 */
 void	define_type(char *value, int *type);
+bool	is_redirect(char *value);
+bool	is_builtin(char *value);
 
 #endif

--- a/includes/tokenizer.h
+++ b/includes/tokenizer.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 14:59:12 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 17:34:00 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 17:44:21 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,7 @@ void	remove_quotes(char **value, char quote);
 void	token_list_clear(t_token **lst);
 t_token	*token_new(char *value, int type);
 void	token_add_back(t_token **lst, t_token *new_token);
+t_token	*token_last(t_token *lst);
 /*
 ** variables_expansion.c
 */
@@ -71,7 +72,7 @@ void	free_var_struct(t_var *var);
 /*
 ** define_type.c
 */
-void	define_type(char *value, int *type);
+void	define_type(t_token *previous, char *value, int *type);
 bool	is_redirect(char *value);
 bool	is_builtin(char *value);
 /*

--- a/sources/tokenizer/add_token.c
+++ b/sources/tokenizer/add_token.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/22 21:11:55 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/18 21:57:16 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 17:43:45 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,6 @@ void	add_token(char *line, int start, int end, t_token **token_lst)
 		check_quotes(&value);
 	else if (ft_strchr(value, '$'))
 		expand_variables(&value);
-	define_type(value, &type);
+	define_type(token_last(*token_lst), value, &type);
 	token_add_back(token_lst, token_new(value, type));
 }

--- a/sources/tokenizer/debugging_temp.c
+++ b/sources/tokenizer/debugging_temp.c
@@ -1,0 +1,47 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   debugging_temp.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/07/21 23:39:22 by phemsi-a          #+#    #+#             */
+/*   Updated: 2021/07/21 23:39:38 by phemsi-a         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/*
+**DEBUGGING FUNC
+*/
+static char	*get_type(int type_id)
+{
+	if (type_id == 42)
+		return (ft_strdup("T_BUILTIN"));
+	if (type_id == 43)
+		return (ft_strdup("T_LITERAL"));
+	if (type_id == 44)
+		return (ft_strdup("T_PIPE"));
+	if (type_id == 45)
+		return (ft_strdup("T_REDIRECT"));
+	if (type_id == 46)
+		return (ft_strdup("T_HERE_DOC"));
+	return (NULL);
+}
+
+/*
+**DEBUGGING FUNC
+*/
+void	print_token_lst(t_token *token_lst)
+{
+	char	*type;
+
+	while (token_lst != NULL)
+	{
+		type = get_type(token_lst->type);
+		ft_printf("type: %s value: %s\n", type, token_lst->value);
+		token_lst = token_lst->next;
+		ft_free_and_null((void **)&type);
+	}
+}

--- a/sources/tokenizer/debugging_temp.c
+++ b/sources/tokenizer/debugging_temp.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/21 23:39:22 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/21 23:39:38 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 19:37:44 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,8 @@ static char	*get_type(int type_id)
 		return (ft_strdup("T_REDIRECT"));
 	if (type_id == 46)
 		return (ft_strdup("T_HERE_DOC"));
+	if (type_id == 47)
+		return (ft_strdup("T_FILE"));
 	return (NULL);
 }
 

--- a/sources/tokenizer/define_type.c
+++ b/sources/tokenizer/define_type.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/10 10:53:17 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/21 23:29:16 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 19:36:42 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,12 +56,19 @@ static int	define_operator(char *value)
 	return (FALSE);
 }
 
-void	define_type(char *value, int *type)
+void	define_type(t_token *previous, char *value, int *type)
 {
-	if (is_builtin(value))
+	int	previous_type;
+
+	previous_type = 0;
+	if (previous)
+		previous_type = previous->type;
+	if (is_builtin(value) && (previous_type != T_REDIRECT))
 		*type = T_BUILTIN;
 	else if (is_operator(value))
 		*type = define_operator(value);
+	else if (previous_type == T_REDIRECT)
+		*type = T_FILE;
 	else
 		*type = T_LITERAL;
 }

--- a/sources/tokenizer/define_type.c
+++ b/sources/tokenizer/define_type.c
@@ -6,13 +6,13 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/10 10:53:17 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/18 21:30:30 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/21 23:29:16 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static bool	is_builtin(char *value)
+bool	is_builtin(char *value)
 {
 	if (!(ft_strcmp(value, "echo\0")) || !(ft_strcmp(value, "cd\0")))
 		return (TRUE);
@@ -25,9 +25,18 @@ static bool	is_builtin(char *value)
 	return (FALSE);
 }
 
+bool	is_redirect(char *value)
+{
+	if (!ft_strcmp(value, ">") || !ft_strcmp(value, "<"))
+		return (TRUE);
+	if (!ft_strcmp(value, ">>"))
+		return (TRUE);
+	return (FALSE);
+}
+
 static bool	is_operator(char *value)
 {
-	if (!(ft_strcmp(value, "|")) || !(ft_strcmp(value, "=")))
+	if (!(ft_strcmp(value, "|")))
 		return (TRUE);
 	if (!(ft_strcmp(value, ">")) || !(ft_strcmp(value, "<")))
 		return (TRUE);
@@ -36,12 +45,23 @@ static bool	is_operator(char *value)
 	return (FALSE);
 }
 
+static int	define_operator(char *value)
+{
+	if (!(ft_strcmp(value, "|")))
+		return (T_PIPE);
+	if (is_redirect(value))
+		return (T_REDIRECT);
+	if (!(ft_strcmp(value, "<<")))
+		return (T_HERE_DOC);
+	return (FALSE);
+}
+
 void	define_type(char *value, int *type)
 {
 	if (is_builtin(value))
 		*type = T_BUILTIN;
 	else if (is_operator(value))
-		*type = T_OPERATOR;
+		*type = define_operator(value);
 	else
 		*type = T_LITERAL;
 }

--- a/sources/tokenizer/token_lst.c
+++ b/sources/tokenizer/token_lst.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/22 19:56:24 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/01 18:23:41 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 17:37:58 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ t_token	*token_new(char *value, int type)
 	new_token->value = value;
 	new_token->type = type;
 	new_token->next = NULL;
+	new_token->previous = NULL;
 	return (new_token);
 }
 
@@ -50,6 +51,7 @@ void	token_add_back(t_token **lst, t_token *new_token)
 	}
 	aux = token_last(*lst);
 	aux->next = new_token;
+	new_token->previous = aux;
 }
 
 void	token_list_clear(t_token **lst)

--- a/sources/tokenizer/token_lst.c
+++ b/sources/tokenizer/token_lst.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/22 19:56:24 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 17:37:58 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 17:43:15 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ t_token	*token_new(char *value, int type)
 	return (new_token);
 }
 
-static t_token	*token_last(t_token *lst)
+t_token	*token_last(t_token *lst)
 {
 	t_token	*aux;
 

--- a/sources/tokenizer/tokenizer.c
+++ b/sources/tokenizer/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/21 11:01:46 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 00:09:28 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 19:42:28 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,56 +27,18 @@ static int	find_end(char *line, int i, int *end)
 	return (i);
 }
 
-static int	split_token(char *line, int *i, int *token_end, t_token **token_lst)
+static int	split_token(char *line, int *i, int *tkn_end, t_token **token_lst)
 {
 	while (ft_isblank(line[*i]))
 		*i += 1;
 	if (!line[*i])
 		return (0);
-	add_token(line, *i, find_end(line, *i, token_end), token_lst);
-	*i = *token_end;
+	add_token(line, *i, find_end(line, *i, tkn_end), token_lst);
+	*i = *tkn_end;
 	if (line[*i])
 		*i += 1;
 	return (1);
 }
-
-// static bool	is_redirect_char(char c)
-// {
-// 	if ((c == '>') || (c == '<'))
-// 		return (TRUE);
-// 	return (FALSE);
-// }
-
-// static void check_and_add_spaces(char **line)
-// {
-// 	int		i;
-// 	t_var	aux;
-// 	char	*line_to_check;
-
-// 	i = 0;
-// 	line_to_check = *line;
-// 	ft_memset(&aux, 0, sizeof(aux));
-// 	while (line_to_check[i])
-// 	{
-// 		if (is_redirect_char(line_to_check[i]))
-// 		{
-// 			i++;
-// 			if (is_redirect_char(line_to_check[i]))
-// 				i++;
-// 			if (line_to_check[i] != ' ')
-// 			{
-// 				aux.before = ft_substr(line_to_check, 0, i - 1);
-// 				aux.value = ft_strdup(" ");
-// 				aux.after = ft_strdup(&line_to_check[i]);
-// 				free(line_to_check);
-// 				line_to_check = variadic_strjoin(3, aux.before, aux.value, aux.after);
-// 				free_var_struct(&aux);
-// 			}
-// 		}
-// 		i++;
-// 	}
-// 	line = &line_to_check;
-// }
 
 void	tokenizer(char *line, t_token **token_lst)
 {
@@ -85,7 +47,6 @@ void	tokenizer(char *line, t_token **token_lst)
 
 	i = 0;
 	token_end = i;
-	//?check_and_add_spaces(&line);
 	while (line[i])
 		if (!split_token(line, &i, &token_end, token_lst))
 			break ;

--- a/sources/tokenizer/tokenizer.c
+++ b/sources/tokenizer/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/21 11:01:46 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/18 21:32:13 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/21 23:35:50 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,9 +20,13 @@ static char	*get_type(int type_id)
 	if (type_id == 42)
 		return (ft_strdup("T_BUILTIN"));
 	if (type_id == 43)
-		return (ft_strdup("T_OPERATOR"));
-	if (type_id == 44)
 		return (ft_strdup("T_LITERAL"));
+	if (type_id == 44)
+		return (ft_strdup("T_PIPE"));
+	if (type_id == 45)
+		return (ft_strdup("T_REDIRECT"));
+	if (type_id == 46)
+		return (ft_strdup("T_HERE_DOC"));
 	return (NULL);
 }
 

--- a/sources/tokenizer/tokenizer.c
+++ b/sources/tokenizer/tokenizer.c
@@ -6,45 +6,11 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/21 11:01:46 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/21 23:35:50 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/22 00:09:28 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-/*
-**DEBUGGING FUNC
-*/
-static char	*get_type(int type_id)
-{
-	if (type_id == 42)
-		return (ft_strdup("T_BUILTIN"));
-	if (type_id == 43)
-		return (ft_strdup("T_LITERAL"));
-	if (type_id == 44)
-		return (ft_strdup("T_PIPE"));
-	if (type_id == 45)
-		return (ft_strdup("T_REDIRECT"));
-	if (type_id == 46)
-		return (ft_strdup("T_HERE_DOC"));
-	return (NULL);
-}
-
-/*
-**DEBUGGING FUNC
-*/
-static void	print_token_lst(t_token *token_lst)
-{
-	char	*type;
-
-	while (token_lst != NULL)
-	{
-		type = get_type(token_lst->type);
-		ft_printf("type: %s value: %s\n", type, token_lst->value);
-		token_lst = token_lst->next;
-		ft_free_and_null((void **)&type);
-	}
-}
 
 static int	find_end(char *line, int i, int *end)
 {
@@ -74,6 +40,44 @@ static int	split_token(char *line, int *i, int *token_end, t_token **token_lst)
 	return (1);
 }
 
+// static bool	is_redirect_char(char c)
+// {
+// 	if ((c == '>') || (c == '<'))
+// 		return (TRUE);
+// 	return (FALSE);
+// }
+
+// static void check_and_add_spaces(char **line)
+// {
+// 	int		i;
+// 	t_var	aux;
+// 	char	*line_to_check;
+
+// 	i = 0;
+// 	line_to_check = *line;
+// 	ft_memset(&aux, 0, sizeof(aux));
+// 	while (line_to_check[i])
+// 	{
+// 		if (is_redirect_char(line_to_check[i]))
+// 		{
+// 			i++;
+// 			if (is_redirect_char(line_to_check[i]))
+// 				i++;
+// 			if (line_to_check[i] != ' ')
+// 			{
+// 				aux.before = ft_substr(line_to_check, 0, i - 1);
+// 				aux.value = ft_strdup(" ");
+// 				aux.after = ft_strdup(&line_to_check[i]);
+// 				free(line_to_check);
+// 				line_to_check = variadic_strjoin(3, aux.before, aux.value, aux.after);
+// 				free_var_struct(&aux);
+// 			}
+// 		}
+// 		i++;
+// 	}
+// 	line = &line_to_check;
+// }
+
 void	tokenizer(char *line, t_token **token_lst)
 {
 	int		i;
@@ -81,6 +85,7 @@ void	tokenizer(char *line, t_token **token_lst)
 
 	i = 0;
 	token_end = i;
+	//?check_and_add_spaces(&line);
 	while (line[i])
 		if (!split_token(line, &i, &token_end, token_lst))
 			break ;


### PR DESCRIPTION
Nova versão do tokenizer, agora é uma lista duplamente encadeada então ficamos livres para ir e voltar no parser caso necessário 

Novos tipos de tokens implementados, agora temos:

* `T_PIPE` para `|` 
* `T_REDIRECT` para `<` `>>` `>`
* `T_HERE_DOC` para `<<`
* `T_FILE` para a palavra que vier depois de um redirect 
* `T_BUILTIN` para `echo` `cd` `pwd` `export` `unset` `env` `exit`
* `T_LITERAL` para todo o resto :)

E se um nome de arquivo for `echo`? Tokenizer entende e classifica como `T_FILE` =D