### PR TITLE
Local vars implementation

### DIFF
--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/11 17:40:26 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/25 03:06:45 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/25 13:36:20 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,12 @@
 
 # include "minishell.h"
 
+# define KEY	0
+# define VALUE	1
+
 /*
 ** ENV:
 */
-
 t_hashmap	*env_to_hashmap(char **env);
 char		**hashmap_to_env(t_hashmap *table);
 char		**hashmap_to_env_with_quotes(t_hashmap *table);
@@ -33,6 +35,7 @@ void		pwd(void);
 void		cd(char *path);
 void		echo(char **cmd);
 void		exit_minishell(void);
+int			set_local_variable(char **cmd);
 
 /**
 ** 2D ARRAY UTILS

--- a/sources/builtins/export.c
+++ b/sources/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/16 20:23:19 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/24 17:14:45 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/25 12:30:42 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,23 +26,35 @@ static int	print_ordered_env(void)
 
 static void	define_variable(char **cmd, int index)
 {
-	char	**key_value;
+	char	**variable;
 
-	key_value = ft_split(cmd[index], '=');
-	hashmap_insert(key_value[0], key_value[1], g_minishell.env);
-	free_2d_array(key_value);
+	variable = ft_split(cmd[index], '=');
+	if (hashmap_search(g_minishell.env, variable[KEY]))
+		hashmap_delete(g_minishell.env, variable[KEY]);
+	hashmap_insert(variable[KEY], variable[VALUE], g_minishell.env);
+	free_2d_array(variable);
 }
 
 static void	update_variable(char **cmd, int index)
 {
 	char	*value;
+	bool	free_value_is_needed;
 
+	free_value_is_needed = FALSE;
+	if (hashmap_search(g_minishell.env, cmd[index]))
+		return ;
 	value = hashmap_search(g_minishell.local_vars, cmd[index]);
 	if (!value)
+	{
 		value = ft_strdup("");
+		free_value_is_needed = TRUE;
+	}
+	if (hashmap_search(g_minishell.env, cmd[index]))
+		hashmap_delete(g_minishell.env, cmd[index]);
 	hashmap_insert(cmd[index], value, g_minishell.env);
 	hashmap_delete(g_minishell.local_vars, cmd[index]);
-	free(value);
+	if (free_value_is_needed)
+		free(value);
 }
 
 static int	export_variable(char **cmd, int index)

--- a/sources/builtins/set_local_variable.c
+++ b/sources/builtins/set_local_variable.c
@@ -1,0 +1,63 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   set_local_variable.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/07/25 10:40:01 by phemsi-a          #+#    #+#             */
+/*   Updated: 2021/07/25 12:29:47 by phemsi-a         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static void	update_variable(t_hashmap *table, char *key, char *value)
+{
+	hashmap_delete(table, key);
+	hashmap_insert(key, value, table);
+}
+
+static void	define_variable(char **cmd, int index)
+{
+	char	**variable;
+
+	variable = ft_split(cmd[index], '=');//!caso de dois iguais não está tratado
+	if (hashmap_search(g_minishell.env, variable[KEY]))
+		update_variable(g_minishell.env, variable[KEY], variable[VALUE]);
+	else if (hashmap_search(g_minishell.local_vars, variable[KEY]))
+		update_variable(g_minishell.local_vars, variable[KEY], variable[VALUE]);
+	else
+		hashmap_insert(variable[KEY], variable[VALUE], g_minishell.local_vars);
+	free_2d_array(variable);
+}
+
+static int	set_variables(char **cmd, int index)
+{
+	if (!cmd[index])
+		return (0);
+	define_variable(cmd, index);
+	return (set_variables(cmd, index + 1));
+}
+
+static bool	is_any_missconfiguration(char **cmd)
+{
+	int	i;
+
+	i = 0;
+	while (cmd[i])
+	{
+		if (!(ft_strchr(cmd[i], '=')))
+			return (TRUE);
+		i++;
+	}
+	return (FALSE);
+}
+
+int	set_local_variable(char **cmd)
+{
+	if (is_any_missconfiguration(cmd))
+		return (0);
+	set_variables(cmd, 0);
+	return (1);
+}

--- a/sources/builtins/set_local_variable.c
+++ b/sources/builtins/set_local_variable.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/25 10:40:01 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/25 12:29:47 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/25 14:00:09 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ static void	define_variable(char **cmd, int index)
 {
 	char	**variable;
 
-	variable = ft_split(cmd[index], '=');//!caso de dois iguais não está tratado
+	variable = ft_split(cmd[index], '=');
 	if (hashmap_search(g_minishell.env, variable[KEY]))
 		update_variable(g_minishell.env, variable[KEY], variable[VALUE]);
 	else if (hashmap_search(g_minishell.local_vars, variable[KEY]))

--- a/sources/builtins/unset.c
+++ b/sources/builtins/unset.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/18 20:32:29 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/24 19:17:24 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/25 13:44:14 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,8 @@ void	unset(char **cmd)
 	{
 		if (hashmap_search(g_minishell.env, cmd[i]))
 			hashmap_delete(g_minishell.env, cmd[i]);
+		else if (hashmap_search(g_minishell.local_vars, cmd[i]))
+			hashmap_delete(g_minishell.local_vars, cmd[i]);
 		i++;
 	}
 }

--- a/sources/parser/command_parser.c
+++ b/sources/parser/command_parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   command_parser.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
+/*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/21 18:02:40 by lfrasson          #+#    #+#             */
-/*   Updated: 2021/07/25 03:07:42 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/25 13:35:55 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,6 +71,8 @@ void	command_parser(t_token *token_lst, t_token *pipe)
 	cmd = create_command_array(token_lst, pipe, cmd);
 	if (is_builtin(cmd[0]))
 		execute_builtin(cmd);
+	else if (ft_strchr(cmd[0], '='))
+		set_local_variable(cmd);
 	else
 		execute_cmd(cmd);
 	free_2d_array(cmd);

--- a/sources/tokenizer/define_type.c
+++ b/sources/tokenizer/define_type.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/10 10:53:17 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/25 11:38:12 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/25 13:37:54 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 bool	is_builtin(char *value)
 {
-	if (/*!(ft_strcmp(value, "echo\0")) ||*/ !(ft_strcmp(value, "cd\0")))
+	if (!(ft_strcmp(value, "echo\0")) || !(ft_strcmp(value, "cd\0")))
 		return (TRUE);
 	if (!(ft_strcmp(value, "pwd")) || !(ft_strcmp(value, "export")))
 		return (TRUE);

--- a/sources/tokenizer/define_type.c
+++ b/sources/tokenizer/define_type.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/10 10:53:17 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 19:36:42 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/25 11:38:12 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 bool	is_builtin(char *value)
 {
-	if (!(ft_strcmp(value, "echo\0")) || !(ft_strcmp(value, "cd\0")))
+	if (/*!(ft_strcmp(value, "echo\0")) ||*/ !(ft_strcmp(value, "cd\0")))
 		return (TRUE);
 	if (!(ft_strcmp(value, "pwd")) || !(ft_strcmp(value, "export")))
 		return (TRUE);


### PR DESCRIPTION
implementei o `=` no fluxo do `command_parser` atribuindo valor às variáveis locais e a partir daí corrigi algumas inconsistências do `export` e do `unset`
(*unset* agora tb funciona para variáveis locais, *export* não tem mais leak quando atribui valor à variável já existente)

falta lidar com caso de variáveis com valor que contenha o caracter `=` no meio, vou abrir uma issue pra isso e arrumo em breve ;)
