### PR TITLE
variables improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added file redirection feature.
 - Added error status tracking.
+### Changed
+- Variables values now accept's equal sign
+- Set variable followed by command is accepted
 
 ## - 2021-07-25
 ### Added

--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/11 17:40:26 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/25 13:36:20 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/27 01:14:47 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ void		pwd(void);
 void		cd(char *path);
 void		echo(char **cmd);
 void		exit_minishell(void);
-int			set_local_variable(char **cmd);
+int			set_local_variable(char **cmd, int *i);
 
 /**
 ** 2D ARRAY UTILS

--- a/includes/tokenizer.h
+++ b/includes/tokenizer.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 14:59:12 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 17:44:21 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/26 22:48:21 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,6 +69,7 @@ void	free_var_struct(t_var *var);
 char	*search_var(char *value, int *i);
 int		get_var_size(char *var, int *index);
 void	free_var_struct(t_var *var);
+char	**split_in_two(const char *string, char c);
 /*
 ** define_type.c
 */

--- a/sources/builtins/echo.c
+++ b/sources/builtins/echo.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/25 02:59:47 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/27 01:46:09 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/27 01:53:43 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ void	echo(char **cmd)
 	int		i;
 
 	i = 1;
-	n_flag = 0;
+	n_flag = false;
 	if (cmd[1] && ft_strcmp(cmd[1], "-n") == 0)
 	{
 		n_flag = true;

--- a/sources/builtins/echo.c
+++ b/sources/builtins/echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   echo.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
+/*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/25 02:59:47 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/25 03:12:16 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/27 01:46:09 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,8 @@ void	echo(char **cmd)
 	int		i;
 
 	i = 1;
-	if (cmd[1] && strcmp(cmd[1], "-n") == 0)
+	n_flag = 0;
+	if (cmd[1] && ft_strcmp(cmd[1], "-n") == 0)
 	{
 		n_flag = true;
 		i = 2;

--- a/sources/builtins/export.c
+++ b/sources/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/16 20:23:19 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/25 12:30:42 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/26 23:08:00 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ static void	define_variable(char **cmd, int index)
 {
 	char	**variable;
 
-	variable = ft_split(cmd[index], '=');
+	variable = split_in_two(cmd[index], '=');
 	if (hashmap_search(g_minishell.env, variable[KEY]))
 		hashmap_delete(g_minishell.env, variable[KEY]);
 	hashmap_insert(variable[KEY], variable[VALUE], g_minishell.env);

--- a/sources/builtins/set_local_variable.c
+++ b/sources/builtins/set_local_variable.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/25 10:40:01 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/27 01:29:30 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/27 01:36:23 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ static t_hashmap	*define_hashtable(char **variable)
 		table = g_minishell.local_vars;
 	else
 		table = NULL;
-	return (table) ;
+	return (table);
 }
 
 static void	define_variable(char **cmd, int index)

--- a/sources/builtins/set_local_variable.c
+++ b/sources/builtins/set_local_variable.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/25 10:40:01 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/26 23:04:13 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/27 01:29:30 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,46 +18,44 @@ static void	update_variable(t_hashmap *table, char *key, char *value)
 	hashmap_insert(key, value, table);
 }
 
+static t_hashmap	*define_hashtable(char **variable)
+{
+	t_hashmap	*table;
+
+	if (hashmap_search(g_minishell.env, variable[KEY]))
+		table = g_minishell.env;
+	else if (hashmap_search(g_minishell.local_vars, variable[KEY]))
+		table = g_minishell.local_vars;
+	else
+		table = NULL;
+	return (table) ;
+}
+
 static void	define_variable(char **cmd, int index)
 {
-	char	**variable;
+	char		**variable;
+	t_hashmap	*table;
 
 	variable = split_in_two(cmd[index], '=');
-	if (hashmap_search(g_minishell.env, variable[KEY]))
-		update_variable(g_minishell.env, variable[KEY], variable[VALUE]);
-	else if (hashmap_search(g_minishell.local_vars, variable[KEY]))
-		update_variable(g_minishell.local_vars, variable[KEY], variable[VALUE]);
+	table = define_hashtable(variable);
+	if (table)
+		update_variable(table, variable[KEY], variable[VALUE]);
 	else
 		hashmap_insert(variable[KEY], variable[VALUE], g_minishell.local_vars);
 	free_2d_array(variable);
 }
 
-static int	set_variables(char **cmd, int index)
+static int	set_variables(char **cmd, int *index)
 {
-	if (!cmd[index])
+	if ((!cmd[*index]) || (!(ft_strchr(cmd[*index], '='))))
 		return (0);
-	define_variable(cmd, index);
-	return (set_variables(cmd, index + 1));
+	define_variable(cmd, *index);
+	*index += 1;
+	return (set_variables(cmd, index));
 }
 
-static bool	is_any_missconfiguration(char **cmd)
+int	set_local_variable(char **cmd, int *i)
 {
-	int	i;
-
-	i = 0;
-	while (cmd[i])
-	{
-		if (!(ft_strchr(cmd[i], '=')))
-			return (TRUE);
-		i++;
-	}
-	return (FALSE);
-}
-
-int	set_local_variable(char **cmd)
-{
-	if (is_any_missconfiguration(cmd))
-		return (0);
-	set_variables(cmd, 0);
+	set_variables(cmd, i);
 	return (1);
 }

--- a/sources/builtins/set_local_variable.c
+++ b/sources/builtins/set_local_variable.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/25 10:40:01 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/25 14:00:09 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/26 23:04:13 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ static void	define_variable(char **cmd, int index)
 {
 	char	**variable;
 
-	variable = ft_split(cmd[index], '=');
+	variable = split_in_two(cmd[index], '=');
 	if (hashmap_search(g_minishell.env, variable[KEY]))
 		update_variable(g_minishell.env, variable[KEY], variable[VALUE]);
 	else if (hashmap_search(g_minishell.local_vars, variable[KEY]))

--- a/sources/exec/execute_command.c
+++ b/sources/exec/execute_command.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/23 11:30:15 by lfrasson          #+#    #+#             */
-/*   Updated: 2021/07/26 22:37:28 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/27 01:21:18 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,8 @@ static int	add_path_to_cmd_name(char **cmd)
 {
 	char	*cmd_name;
 
+	if (!cmd[0])
+		return (0);
 	cmd_name = get_absolute_path(cmd[0]);
 	if (!cmd_name)
 	{
@@ -34,7 +36,7 @@ void	execute_cmd(char **cmd)
 	int		status;
 	char	**env_variables;
 
-	if (!add_path_to_cmd_name(cmd))
+	if ((!cmd[0]) || (!add_path_to_cmd_name(cmd)))
 		return ;
 	pid = fork();
 	define_exec_signals();

--- a/sources/parser/command_parser.c
+++ b/sources/parser/command_parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   command_parser.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
+/*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/21 18:02:40 by lfrasson          #+#    #+#             */
-/*   Updated: 2021/07/26 21:10:05 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/27 01:16:02 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,19 +63,21 @@ static void	execute_builtin(char **cmd)
 void	command_parser(t_token *token_lst, t_token *pipe)
 {
 	char	**cmd;
+	int		i;
 
+	i = 0;
 	save_std_fds();
 	create_pipe(pipe);
 	check_redirects(token_lst, pipe);
 	cmd = NULL;
 	cmd = create_command_array(token_lst, pipe, cmd);
 	g_minishell.error_status = 0;
-	if (is_builtin(cmd[0]))
-		execute_builtin(cmd);
-	else if (ft_strchr(cmd[0], '='))
-		set_local_variable(cmd);
+	if (ft_strchr(cmd[i], '='))
+		set_local_variable(cmd, &i);
+	if (is_builtin(cmd[i]))
+		execute_builtin(&cmd[i]);
 	else
-		execute_cmd(cmd);
+		execute_cmd(&cmd[i]);
 	free_2d_array(cmd);
 	restore_std_fds();
 }

--- a/sources/tokenizer/define_type.c
+++ b/sources/tokenizer/define_type.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/10 10:53:17 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/25 13:37:54 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/27 01:18:53 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 
 bool	is_builtin(char *value)
 {
+	if (!value)
+		return (FALSE);
 	if (!(ft_strcmp(value, "echo\0")) || !(ft_strcmp(value, "cd\0")))
 		return (TRUE);
 	if (!(ft_strcmp(value, "pwd")) || !(ft_strcmp(value, "export")))

--- a/sources/tokenizer/variables_utils.c
+++ b/sources/tokenizer/variables_utils.c
@@ -6,11 +6,24 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/18 22:00:35 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/18 22:03:32 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/26 23:10:49 by phemsi-a         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+char	**split_in_two(const char *string, char c)
+{
+	char	**splited_strings;
+	char	*c_ptr;
+
+	splited_strings = (char **)malloc(3 * sizeof(char *));
+	c_ptr = ft_strchr(string, c);
+	splited_strings[0] = ft_substr(string, 0, (c_ptr - string));
+	splited_strings[1] = ft_substr((c_ptr + 1), 0, ft_strlen(c_ptr));
+	splited_strings[2] = NULL;
+	return (splited_strings);
+}
 
 char	*search_var(char *value, int *i)
 {


### PR DESCRIPTION
- função `split_in_two` adicionada, funciona como a split mas divide a string em apenas duas, na primeira ocorrência do char passado como parâmetro
- agora as variáveis aceitam valores com `=` no meio

```
$> VAR=oi=oi=oi=oi
$> echo $VAR
oi=oi=oi=oi
$>
```

- é possível atribuir valor a uma variável e na sequência realizar um comando
- `set_local_variable` refatorada


- `n_flag` na função `echo` inicializada para parar warning do valgrind