### PR TITLE
fixed memory leaks/oldpwd bug

### DIFF
--- a/sources/builtins/cd.c
+++ b/sources/builtins/cd.c
@@ -6,53 +6,68 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/21 20:33:57 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/26 21:03:21 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/29 00:29:21 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	change_directory(char *path)
+static void	change_dir_to_path(char *path)
 {
 	char	*pwd;
-	char	*buffer;
+	char	buffer[2048];
 
-	hashmap_insert
-	(
-		"OLDPWD",
-		hashmap_search(g_minishell.env, "PWD"),
-		g_minishell.env
-	);
+	pwd = getcwd(buffer, 2048);
+	hashmap_insert("OLDPWD", pwd, g_minishell.env);
 	if (chdir(path) != 0 && ft_strchr(path, '>') == NULL)
 	{
 		error_message("cd", strerror(errno));
 		g_minishell.error_status = 1;
 		return ;
 	}
-	buffer = NULL;
-	pwd = getcwd(buffer, 0);
+	pwd = getcwd(buffer, 2048);
 	hashmap_insert("PWD", pwd, g_minishell.env);
-	free(pwd);
+}
+
+static void	change_dir_to_oldpwd(char *path)
+{
+	ft_printf("%s\n", path);
+	change_dir_to_path(path);
+}
+
+static void	change_dir_to_home(void)
+{
+	char	*path;
+
+	path = ft_strdup(hashmap_search(g_minishell.env, "HOME"));
+	change_dir_to_path(path);
+	free(path);
 }
 
 void	cd(char	*path)
 {
+	char	*current_path;
+
 	if ((!path) || ft_strcmp(path, "~") == 0)
 	{
-		change_directory(hashmap_search(g_minishell.env, "HOME"));
+		change_dir_to_home();
 		return ;
 	}
 	else if (ft_strcmp(path, "-") == 0)
 	{
-		if (!hashmap_search(g_minishell.env, "OLDPWD"))
+		current_path = ft_strdup(hashmap_search(g_minishell.env, "OLDPWD"));
+		if (current_path == NULL)
 		{
 			error_message("cd", NO_OLDPWD);
 			g_minishell.error_status = 1;
 			return ;
 		}
-		ft_printf("%s\n", hashmap_search(g_minishell.env, "OLDPWD"));
-		change_directory(hashmap_search(g_minishell.env, "OLDPWD"));
+		change_dir_to_oldpwd(current_path);
 	}
 	else
-		change_directory(path);
+	{
+		current_path = ft_strdup(path);
+		change_dir_to_path(current_path);
+	}
+	free(current_path);
 }

--- a/sources/hashmap/hashmap_insert.c
+++ b/sources/hashmap/hashmap_insert.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   hashmap_insert.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lcouto <lcouto@student.42.fr>              +#+  +:+       +#+        */
+/*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/07 19:56:48 by user42            #+#    #+#             */
-/*   Updated: 2021/07/11 17:07:25 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/29 00:28:52 by lcouto           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ void	hashmap_insert(char *key, char *value, t_hashmap *table)
 		{
 			free(current->value);
 			current->value = ft_strdup(value);
+			hashmap_free_pair(new_pair);
 		}
 		else
 			hashmap_handle_collision(table, index, new_pair);


### PR DESCRIPTION
Depois de uma noite inteira de PROGRAMAÇÃO ORIENTADA A ÓDIO, acho que resolvi os memory leaks no hashmap e os bugs na função `cd`. Aparentemente o terminal zsh do vscode é BUGADO e o comando `cd -` não funciona nele, mas funciona no zsh rodando no emulador de terminal ou no bash mesmo.

![image](https://user-images.githubusercontent.com/57910428/127427432-6b239f53-cd74-4959-b3b4-c060a56b4e6a.png)

Me avisem se acharem mais algum bug.

Resolves #82 
Resolves #90 
