### PR TITLE
Include redirect syntax parser

### DIFF
--- a/includes/error.h
+++ b/includes/error.h
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/29 21:17:17 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/21 21:50:49 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/29 21:40:39 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@
 # define NO_OLDPWD "OLDPWD environment variable has not been set."
 
 # define NO_FILE_OR_DIR "no such file or directory."
+
+# define SYNTAX_ERROR "syntax error."
 
 /*
 ** ERROR HANDLING FUNCTIONS:

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 15:12:51 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/26 19:39:29 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/29 22:03:32 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,6 @@ char	*variadic_strjoin(unsigned int arg_quantity, ...);
 */
 
 char	*get_absolute_path(char *cmd);
-void	execute_cmd(char **cmd);
+void	execute(char **cmd);
 
 #endif

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/27 15:09:54 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/26 13:58:49 by lfrasson         ###   ########.fr       */
+/*   Updated: 2021/07/29 21:59:44 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,6 @@
 void	parse_and_execute(t_token *token_lst);
 void	command_parser(t_token *token_lst, t_token *pipe);
 void	check_redirects(t_token *token_lst, t_token *pipe);
-char	**create_command_array(t_token *head, t_token *pipe, char **cmd);
+char	**create_command_array(t_token *head, t_token *pipe);
 
 #endif

--- a/sources/exec/execute_command.c
+++ b/sources/exec/execute_command.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/23 11:30:15 by lfrasson          #+#    #+#             */
-/*   Updated: 2021/07/27 01:21:18 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/29 22:02:22 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,25 @@ static int	add_path_to_cmd_name(char **cmd)
 	return (1);
 }
 
-void	execute_cmd(char **cmd)
+static void	execute_builtin(char **cmd)
+{
+	if (!(ft_strcmp(cmd[0], "echo\0")))
+		echo(cmd);
+	else if (!(ft_strcmp(cmd[0], "cd\0")))
+		cd(cmd[1]);
+	else if (!(ft_strcmp(cmd[0], "pwd")))
+		pwd();
+	else if (!(ft_strcmp(cmd[0], "export")))
+		export(cmd);
+	else if (!(ft_strcmp(cmd[0], "unset")))
+		unset(cmd);
+	else if (!(ft_strcmp(cmd[0], "env")))
+		print_environment(g_minishell.env, STDOUT_FILENO);
+	else if (!(ft_strcmp(cmd[0], "exit")))
+		exit_minishell();
+}
+
+static void	execute_cmd(char **cmd)
 {
 	int		pid;
 	int		status;
@@ -49,4 +67,21 @@ void	execute_cmd(char **cmd)
 	waitpid(pid, &status, 0);
 	if (WIFEXITED(status))
 		g_minishell.error_status = WEXITSTATUS(status);
+}
+
+void	execute(char **cmd)
+{
+	int	i;
+
+	i = 0;
+	g_minishell.error_status = 0;
+	if (cmd[i])
+	{
+		if (ft_strchr(cmd[i], '='))
+			set_local_variable(cmd, &i);
+	}
+	if (is_builtin(cmd[i]))
+		execute_builtin(&cmd[i]);
+	else
+		execute_cmd(&cmd[i]);
 }

--- a/sources/parser/parse_command.c
+++ b/sources/parser/parse_command.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/21 14:51:16 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/22 01:26:42 by lfrasson         ###   ########.fr       */
+/*   Updated: 2021/07/29 21:58:55 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,9 +50,10 @@ static char	**fill_command_array(t_token *current, t_token *end, char **cmd)
 	return (cmd);
 }
 
-char	**create_command_array(t_token *head, t_token *pipe, char **cmd)
+char	**create_command_array(t_token *head, t_token *pipe)
 {
-	int	cmd_length;
+	char	**cmd;
+	int		cmd_length;
 
 	cmd_length = get_commands_length(head, pipe);
 	cmd = (char **)malloc((cmd_length + 1) * sizeof(char *));


### PR DESCRIPTION
Corrige os casos:
echo >>
bash: erro de sintaxe próximo ao token inesperado `newline'

echo >
bash: erro de sintaxe próximo ao token inesperado `newline'