### PR TITLE
Exit arguments

### DIFF
--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/11 17:40:26 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/27 01:14:47 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/31 17:52:14 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ void		unset(char **cmd);
 void		pwd(void);
 void		cd(char *path);
 void		echo(char **cmd);
+void		exit_builtin(char **cmd);
 void		exit_minishell(void);
 int			set_local_variable(char **cmd, int *i);
 

--- a/includes/error.h
+++ b/includes/error.h
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/06/29 21:17:17 by lcouto            #+#    #+#             */
-/*   Updated: 2021/07/29 21:40:39 by lfrasson         ###   ########.fr       */
+/*   Updated: 2021/07/31 19:13:08 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,13 +21,15 @@
 
 # define NOT_FOUND "command not found."
 
-# define TOO_MANY_ARGS "this program doesn't expect any arguments."
+# define TOO_MANY_ARGS "too many arguments."
 
 # define NO_OLDPWD "OLDPWD environment variable has not been set."
 
 # define NO_FILE_OR_DIR "no such file or directory."
 
 # define SYNTAX_ERROR "syntax error."
+
+# define NUM_ARG_REQUIRED "numeric argument required."
 
 /*
 ** ERROR HANDLING FUNCTIONS:

--- a/sources/builtins/exit.c
+++ b/sources/builtins/exit.c
@@ -1,0 +1,59 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exit.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfrasson <lfrasson@student.42sp.org.b      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/07/31 17:29:00 by lfrasson          #+#    #+#             */
+/*   Updated: 2021/07/31 21:05:40 by lfrasson         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	is_string_number(char *string)
+{
+	while (*string)
+		if (!ft_isdigit(*string++))
+			return (FALSE);
+	return (TRUE);
+}
+
+static void	parse_first_arg(char *arg)
+{
+	if (!arg)
+		return ;
+	g_minishell.error_status = atoi(arg);
+	if (is_string_number(arg))
+		return ;
+	error_message("exit", NUM_ARG_REQUIRED);
+	g_minishell.error_status = 2;
+	exit_minishell();
+}
+
+static int	get_argc(char **argv)
+{
+	int	argc;
+
+	argc = 0;
+	while (*(++argv))
+		argc++;
+	return (argc);
+}
+
+void	exit_builtin(char **argv)
+{
+	int	argc;
+
+	argc = get_argc(argv);
+	parse_first_arg(*(argv + 1));
+	if (argc > 1)
+	{
+		error_message("exit", TOO_MANY_ARGS);
+		g_minishell.error_status = 1;
+		return ;
+	}
+	ft_printf("exit\n");
+	exit_minishell();
+}

--- a/sources/builtins/exit_minishell.c
+++ b/sources/builtins/exit_minishell.c
@@ -6,7 +6,7 @@
 /*   By: phemsi-a <phemsi-a@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/24 17:58:18 by phemsi-a          #+#    #+#             */
-/*   Updated: 2021/07/24 17:59:01 by phemsi-a         ###   ########.fr       */
+/*   Updated: 2021/07/31 17:48:05 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,5 +16,5 @@ void	exit_minishell(void)
 {
 	hashmap_free_table(g_minishell.env);
 	hashmap_free_table(g_minishell.local_vars);
-	exit(0);
+	exit(g_minishell.error_status);
 }

--- a/sources/exec/execute_command.c
+++ b/sources/exec/execute_command.c
@@ -6,7 +6,7 @@
 /*   By: lcouto <lcouto@student.42sp.org.br>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/07/23 11:30:15 by lfrasson          #+#    #+#             */
-/*   Updated: 2021/07/30 10:50:59 by lcouto           ###   ########.fr       */
+/*   Updated: 2021/07/31 18:03:14 by lfrasson         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ static void	execute_builtin(char **cmd)
 	else if (!(ft_strcmp(cmd[0], "env")))
 		print_environment(g_minishell.env, STDOUT_FILENO);
 	else if (!(ft_strcmp(cmd[0], "exit")))
-		exit_minishell();
+		exit_builtin(cmd);
 }
 
 static void	execute_cmd(char **cmd)
@@ -74,7 +74,6 @@ void	execute(char **cmd)
 	int	i;
 
 	i = 0;
-	g_minishell.error_status = 0;
 	if (cmd[i])
 	{
 		if (ft_strchr(cmd[i], '='))


### PR DESCRIPTION
Sem argumento -> Finaliza o minishell com o status do último comando
1 argumento -> Finaliza o minishell com o valor passado como argumento

erro "numeric argument required."-> quando pelo menos o 1˚ não é numérico
erro "too many arguments." -> quando o 1˚ é um numero mas não é o único
